### PR TITLE
Update runwarehouse.md

### DIFF
--- a/doc/runwarehouse.md
+++ b/doc/runwarehouse.md
@@ -23,7 +23,7 @@ IIB is now running and waiting for App Connect to register.
 
 ## Configuring the Webhook definition file
 1.  Make a copy of the [Warehouse Webhook definition file](./warehousedefinition.yaml) file and open the file in either a text editor or, for a better presentation, the online [Swagger editor](http://editor.swagger.io/):
-2.  Change the host and port to have the correct values for your IIB system. The HTTP port defaults to 7800 and you can change the protocol to HTTPS if you want to.
+2.  Change the host and port to have the correct values for your IIB system. The HTTP port defaults to 7800 and you can change the protocol to HTTPS if required.
 
 The Webhook definition file is ready to be used by App Connect
 


### PR DESCRIPTION
Suggest that we tell users to update from http to https "if required" (rather than "if you want to").  The user probably doesn't have a choice, the protocol must match the protocol of the host
